### PR TITLE
パターン検出の強化: mode遷移・AI加工判定・window_title分析

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1,6 +1,13 @@
 import { parseLogs } from "./parser.js";
 import { getSessions } from "./db.js";
-import type { AnalysisResult, SessionSequence, VoiceSession } from "./types.js";
+import type {
+  AnalysisResult,
+  SessionSequence,
+  VoiceSession,
+  ModeRetry,
+  AiTransformSession,
+  WindowContext,
+} from "./types.js";
 
 const MODE_NAMES: Record<number, string> = {
   0: "dictate",
@@ -236,4 +243,237 @@ export function getSessionSequences(): SessionSequence[] {
       apps: Array.from(data.apps),
     }))
     .sort((a, b) => b.count - a.count);
+}
+
+// ── Pattern 2: Mode retries (same transcript, different mode within short time) ──
+
+export function detectModeRetries(maxGapSeconds: number = 60): ModeRetry[] {
+  const sessions = getSessions({ limit: 10000 });
+  const sorted = [...sessions].sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  const retries: ModeRetry[] = [];
+
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const curr = sorted[i]!;
+    const next = sorted[i + 1]!;
+
+    if (curr.mode === next.mode) continue;
+    if (!curr.transcript || !next.transcript) continue;
+
+    const gap =
+      (new Date(next.created_at).getTime() -
+        new Date(curr.created_at).getTime()) /
+      1000;
+    if (gap > maxGapSeconds) continue;
+
+    // Check transcript similarity: exact match or one contains the other
+    const t1 = curr.transcript.trim();
+    const t2 = next.transcript.trim();
+    const similar =
+      t1 === t2 ||
+      t1.includes(t2) ||
+      t2.includes(t1) ||
+      (t1.length > 5 &&
+        t2.length > 5 &&
+        levenshteinRatio(t1, t2) > 0.7);
+
+    if (similar) {
+      retries.push({
+        firstSession: {
+          id: curr.id,
+          transcript: curr.transcript,
+          mode: MODE_NAMES[curr.mode] ?? `unknown(${curr.mode})`,
+          created_at: curr.created_at,
+        },
+        retrySession: {
+          id: next.id,
+          transcript: next.transcript,
+          mode: MODE_NAMES[next.mode] ?? `unknown(${next.mode})`,
+          created_at: next.created_at,
+        },
+        gapSeconds: Math.round(gap * 10) / 10,
+        app_name: curr.app_name ?? next.app_name,
+        window_title: curr.window_title ?? next.window_title,
+      });
+    }
+  }
+
+  return retries;
+}
+
+function levenshteinRatio(a: string, b: string): number {
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+
+  const matrix: number[][] = [];
+  for (let i = 0; i <= a.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= b.length; j++) {
+    matrix[0]![j] = j;
+  }
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i]![j] = Math.min(
+        matrix[i - 1]![j]! + 1,
+        matrix[i]![j - 1]! + 1,
+        matrix[i - 1]![j - 1]! + cost
+      );
+    }
+  }
+
+  return 1 - matrix[a.length]![b.length]! / maxLen;
+}
+
+// ── Pattern 4: AI transform detection (transcript vs generated_text) ──
+
+export function detectAiTransforms(): {
+  sessions: AiTransformSession[];
+  summary: {
+    passthrough: number;
+    ai_transformed: number;
+    no_output: number;
+    total: number;
+  };
+} {
+  const sessions = getSessions({ limit: 10000 });
+
+  const results: AiTransformSession[] = sessions.map((s) => {
+    let transformType: AiTransformSession["transformType"];
+
+    if (!s.generated_text) {
+      transformType = "no_output";
+    } else if (
+      s.transcript &&
+      s.generated_text.trim() === s.transcript.trim()
+    ) {
+      transformType = "passthrough";
+    } else {
+      transformType = "ai_transformed";
+    }
+
+    return {
+      id: s.id,
+      transcript: s.transcript,
+      generated_text: s.generated_text,
+      app_name: s.app_name,
+      mode: MODE_NAMES[s.mode] ?? `unknown(${s.mode})`,
+      transformType,
+      created_at: s.created_at,
+    };
+  });
+
+  const summary = {
+    passthrough: results.filter((r) => r.transformType === "passthrough").length,
+    ai_transformed: results.filter((r) => r.transformType === "ai_transformed")
+      .length,
+    no_output: results.filter((r) => r.transformType === "no_output").length,
+    total: results.length,
+  };
+
+  return { sessions: results, summary };
+}
+
+// ── Pattern 5: Window title context analysis ──
+
+export function analyzeWindowContexts(): {
+  contexts: WindowContext[];
+  urlPatterns: { pattern: string; count: number; apps: string[] }[];
+} {
+  const sessions = getSessions({ limit: 10000 });
+
+  // Group by app_name + window_title
+  const contextMap = new Map<
+    string,
+    {
+      app_name: string;
+      window_title: string;
+      count: number;
+      modes: Record<string, number>;
+      transcripts: string[];
+    }
+  >();
+
+  for (const s of sessions) {
+    if (!s.app_name || !s.window_title) continue;
+    const key = `${s.app_name}|${s.window_title}`;
+    const existing = contextMap.get(key) ?? {
+      app_name: s.app_name,
+      window_title: s.window_title,
+      count: 0,
+      modes: {},
+      transcripts: [],
+    };
+    existing.count++;
+    const mode = MODE_NAMES[s.mode] ?? `unknown(${s.mode})`;
+    existing.modes[mode] = (existing.modes[mode] ?? 0) + 1;
+    if (s.transcript) {
+      existing.transcripts.push(s.transcript);
+    }
+    contextMap.set(key, existing);
+  }
+
+  const contexts: WindowContext[] = Array.from(contextMap.values())
+    .map((c) => ({
+      app_name: c.app_name,
+      window_title: c.window_title,
+      sessionCount: c.count,
+      modes: c.modes,
+      transcripts: c.transcripts.slice(0, 10),
+    }))
+    .sort((a, b) => b.sessionCount - a.sessionCount);
+
+  // Extract URL patterns from window titles
+  const urlRegex =
+    /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+\.[a-zA-Z]{2,})(?:\/[^\s]*)*/g;
+  const urlCounts = new Map<
+    string,
+    { count: number; apps: Set<string> }
+  >();
+
+  for (const s of sessions) {
+    if (!s.window_title) continue;
+    const matches = s.window_title.matchAll(urlRegex);
+    for (const m of matches) {
+      const domain = m[1]!;
+      const existing = urlCounts.get(domain) ?? {
+        count: 0,
+        apps: new Set(),
+      };
+      existing.count++;
+      if (s.app_name) existing.apps.add(s.app_name);
+      urlCounts.set(domain, existing);
+    }
+  }
+
+  // Also extract paths from window titles that look like file paths
+  const pathRegex = /[~\/][\w\-\.\/]+/g;
+  for (const s of sessions) {
+    if (!s.window_title) continue;
+    const matches = s.window_title.matchAll(pathRegex);
+    for (const m of matches) {
+      const path = m[0]!;
+      const existing = urlCounts.get(path) ?? {
+        count: 0,
+        apps: new Set(),
+      };
+      existing.count++;
+      if (s.app_name) existing.apps.add(s.app_name);
+      urlCounts.set(path, existing);
+    }
+  }
+
+  const urlPatterns = Array.from(urlCounts.entries())
+    .map(([pattern, data]) => ({
+      pattern,
+      count: data.count,
+      apps: Array.from(data.apps),
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  return { contexts, urlPatterns };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,9 @@ import {
   getErrorPatterns,
   getSessionDetail,
   getSessionSequences,
+  detectModeRetries,
+  detectAiTransforms,
+  analyzeWindowContexts,
 } from "./analyzer.js";
 
 const server = new McpServer({
@@ -143,6 +146,46 @@ server.tool(
 );
 
 server.tool(
+  "voiceos_mode_retries",
+  "Detect sessions where the user retried the same utterance in a different mode (e.g., dictate then write). Reveals cases where a mode didn't meet expectations, suggesting a tool that bridges the gap.",
+  {
+    max_gap_seconds: z.optional(
+      z.number().describe("Max time gap between sessions to consider a retry (default 60)")
+    ),
+  },
+  async (params) => {
+    const retries = detectModeRetries(params.max_gap_seconds);
+    return {
+      content: [{ type: "text", text: JSON.stringify(retries, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "voiceos_ai_transforms",
+  "Compare transcript (what user said) vs generated_text (what was output). Categorizes each session as: passthrough (identical), ai_transformed (AI rewrote it), or no_output. Reveals where AI adds value vs just echoing.",
+  {},
+  async () => {
+    const transforms = detectAiTransforms();
+    return {
+      content: [{ type: "text", text: JSON.stringify(transforms, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "voiceos_window_contexts",
+  "Analyze window titles to understand what the user was working on during voice sessions. Extracts URLs, file paths, and groups sessions by context. Reveals situation-specific automation opportunities.",
+  {},
+  async () => {
+    const contexts = analyzeWindowContexts();
+    return {
+      content: [{ type: "text", text: JSON.stringify(contexts, null, 2) }],
+    };
+  }
+);
+
+server.tool(
   "voiceos_custom_instructions",
   "Read user-defined per-app custom instructions. These reveal what the user has explicitly configured for specific apps.",
   {},
@@ -234,6 +277,9 @@ const ANALYSIS_GUIDE = `# VoiceOS Log Analyzer — 分析ガイド
 - 頻出アプリ → \`voiceos_app_usage\` で transcript を全件読む
 - エラーが多い → \`voiceos_error_patterns\` で原因を特定
 - 連続操作 → \`voiceos_session_sequences\` でマルチステップを発見
+- モードやり直し → \`voiceos_mode_retries\` で dictate→write 等のリトライを検出
+- AI加工パターン → \`voiceos_ai_transforms\` で口述そのまま vs AI 変換を分類
+- 作業コンテキスト → \`voiceos_window_contexts\` でURL/ファイルパス別の使い方を分析
 
 ### Step 3: 具体的なセッションを精査
 - \`voiceos_search_transcripts\` でキーワード検索

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,15 +54,38 @@ export interface SessionSequence {
   apps: string[];
 }
 
-export interface WorkflowSuggestion {
-  toolName: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-  rationale: string;
-  confidence: "high" | "medium" | "low";
-  supportingData: {
-    occurrences: number;
-    exampleTranscripts: string[];
-    involvedApps: string[];
+export interface ModeRetry {
+  firstSession: {
+    id: string;
+    transcript: string | null;
+    mode: string;
+    created_at: string;
   };
+  retrySession: {
+    id: string;
+    transcript: string | null;
+    mode: string;
+    created_at: string;
+  };
+  gapSeconds: number;
+  app_name: string | null;
+  window_title: string | null;
+}
+
+export interface AiTransformSession {
+  id: string;
+  transcript: string | null;
+  generated_text: string | null;
+  app_name: string | null;
+  mode: string;
+  transformType: "passthrough" | "ai_transformed" | "no_output";
+  created_at: string;
+}
+
+export interface WindowContext {
+  app_name: string;
+  window_title: string;
+  sessionCount: number;
+  modes: Record<string, number>;
+  transcripts: string[];
 }


### PR DESCRIPTION
## Summary
- `voiceos_mode_retries`: 同じ発話を別モードでやり直したパターンを検出（例: dictate→write で12秒後にリトライ）
- `voiceos_ai_transforms`: transcript と generated_text を比較し、passthrough / ai_transformed / no_output に分類
- `voiceos_window_contexts`: window_title から URL・ファイルパスを抽出し、作業コンテキスト別にセッションをグルーピング

Closes #3

## Test plan
- [x] `pnpm build` 成功
- [x] `voiceos_mode_retries` — luma.com の dictate→write リトライを検出
- [x] `voiceos_ai_transforms` — dictate=passthrough, agent=ai_transformed を正しく分類
- [x] `voiceos_window_contexts` — luma.com URL と ~/Documents/voiceos パスを抽出

🤖 Generated with [Claude Code](https://claude.com/claude-code)